### PR TITLE
Add Bugsy.show_bug for exposing public URLs.

### DIFF
--- a/bugsy/bugsy.py
+++ b/bugsy/bugsy.py
@@ -90,6 +90,21 @@ class Bugsy(object):
                 else:
                     raise LoginException(result['message'])
 
+    def bug_url(self, bug_number):
+        """
+            Get the public URL to a bug.  This is the HTTP accessible URL, not
+            the REST accessible URL which the Bugzilla REST API uses.
+
+            :param bug_number: Bug Number to get URL for.
+
+            >>> bugzilla = Bugsy(bugzilla_url="https://test_bugzilla.mozilla.org/test/rest")
+            >>> bugzilla.bug_url(123456)
+            "https://test_bugzilla.mozilla.org/test/showbug.cgi?id=123456"
+        """
+        import urllib
+        url, _ = self.bugzilla_url.rsplit('/rest', 1)
+        return '%s/showbug.cgi?%s' % (url, urllib.urlencode({'id': bug_number}))
+
     def get(self, bug_number):
         """
             Get a bug from Bugzilla. If there is a login token created during object initialisation

--- a/tests/test_bugsy.py
+++ b/tests/test_bugsy.py
@@ -166,4 +166,8 @@ def test_we_can_set_the_user_agent_to_bugsy():
   Bugsy("foo", "bar")
   assert responses.calls[0].request.headers['User-Agent'] == "Bugsy"
 
-
+def test_bug_url():
+  bugzilla = Bugsy()
+  assert bugzilla.bug_url(123456) == 'https://bugzilla.mozilla.org/showbug.cgi?id=123456'
+  assert bugzilla.bug_url('alias') == 'https://bugzilla.mozilla.org/showbug.cgi?id=alias'
+  assert bugzilla.bug_url('alias with spaces') == 'https://bugzilla.mozilla.org/showbug.cgi?id=alias+with+spaces'


### PR DESCRIPTION
I want to use this to show bug URLs when I push to Mozilla hg.  Bug XXX is not clickable in my shell (iTerm) whereas a full URL is.

@indygreg patch against v-c-t will come shortly.