### PR TITLE
Docs improvements

### DIFF
--- a/bugsy/bug.py
+++ b/bugsy/bug.py
@@ -251,15 +251,19 @@ class Bug(object):
 
     def add_comment(self, comment):
         """
-            Adds a comment to a bug. If a bug does not have a bug ID then
-            you need call `put` on the :class:`Bugsy` class.
+            Adds a comment to a bug. If the bug object does not have a bug ID
+            (ie you are creating a bug) then you will need to also call `put`
+            on the :class:`Bugsy` class.
 
             >>> bug.add_comment("I like sausages")
             >>> bugzilla.put(bug)
 
-            If it does have a bug id then this will do a post to the server
+            If it does have a bug id then this will immediately post to the server
 
             >>> bug.add_comment("I like eggs too")
+
+            More examples can be found at:
+            https://github.com/AutomatedTester/Bugsy/blob/master/example/add_comments.py
         """
         # If we have a key post immediately otherwise hold onto it until
         # put(bug) is called

--- a/docs/source/bug.rst
+++ b/docs/source/bug.rst
@@ -6,5 +6,6 @@
 .. automodule:: bugsy
 .. autoclass:: Bug
    :members:
+   :special-members:
 .. autoclass:: BugException
    :members:

--- a/docs/source/bugsy.rst
+++ b/docs/source/bugsy.rst
@@ -6,6 +6,7 @@
 .. automodule:: bugsy
 .. autoclass:: Bugsy
    :members:
+   :special-members:
 .. autoclass:: BugsyException
    :members:
 .. autoclass:: LoginException

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -74,7 +74,7 @@ Searching Bugzilla
 
 To search for bugs you will need to create a :class:`Bugsy` object and then you can call
 `search_for` and chain the search. The :class:`Search` API is a `Fluent API <https://en.wikipedia.org/wiki/Fluent_interface>`_
-o you just chain the items that you need and then call `search` when the search is complete.
+- you just chain the items that you need and then call `search` when the search is complete.
 
 .. code-block:: python
 
@@ -106,7 +106,7 @@ Adding comments to a bug
 
     import bugsy
     bugzilla = bugsy.Bugsy()
-    bug = bugzilla.get(123456)
+    bug = bugsy.Bug(bugsy=bugzilla, id=123456)
     bug.add_comment("And I love bacon too!")
 
 To see further details look at:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -114,6 +114,7 @@ To see further details look at:
 .. toctree::
    :maxdepth: 2
 
+   index.rst
    bugsy.rst
    bug.rst
    comment.rst

--- a/docs/source/search_bug.rst
+++ b/docs/source/search_bug.rst
@@ -7,3 +7,4 @@
 .. automodule:: bugsy
 .. autoclass:: Search
    :members:
+   :special-members:

--- a/example/add_comments.py
+++ b/example/add_comments.py
@@ -1,8 +1,16 @@
 import bugsy
 bz = bugsy.Bugsy("username", "password", "https://bugzilla-dev.allizom.org/rest")
+
+# Create a new bug with a comment 0 set.
 bug = bugsy.Bug()
 bug.summary = "I love cheese"
 bug.add_comment('I do love sausages too')
 bz.put(bug)
 
+# Add another comment to that bug.
 bug.add_comment('I do love eggs too')
+
+# Add a comment to an existing bug for whom we don't
+# have a bug object (and don't wish to fetch it).
+bug = bugsy.Bug(bugsy=bz, id=123456)
+bug.add_comment("I love cheese")


### PR DESCRIPTION
**1) Make sure Sphinx autodoc generates docs for Class ``__init__`` methods**
The docstrings for several ``__init__`` methods currently don't show up on Read the Docs, since Sphinx ignores anything with an underscore, since it believe it to be private (sigh). See:
http://sphinx-doc.org/ext/autodoc.html
http://stackoverflow.com/a/5599712

**2) Make sure the docs index page is listed in the sidebar table of contents (fixes #21).**

**3) Improve the docs & examples for add_comment()**
Make it clearer that comments can be added without having to fetch the bug first (unlike other operations, there's no need to have the rest of the bug metadata to just add a comment). Also fix a typo in index.rst.
