### PR TITLE
handle valid_login error checking a bit better

### DIFF
--- a/bugsy/bugsy.py
+++ b/bugsy/bugsy.py
@@ -67,7 +67,9 @@ class Bugsy(object):
                     params={'login': self.username}
                 )
 
-                if result is not True:
+                if type(result) == bool and not result:
+                    raise LoginException("login name doesn't match api key")
+                elif type(result) == dict:
                     raise LoginException(result['message'])
 
             self.session.headers['X-Bugzilla-API-Key'] = self.api_key


### PR DESCRIPTION
valid_login can return False if the login name provided doesn't match. This bubbles up that error in a way that is less likely to be confusing.