### PR TITLE
Cannot retrieve depends_on field

### DIFF
--- a/bugsy/bugsy.py
+++ b/bugsy/bugsy.py
@@ -11,7 +11,7 @@ class Bugsy(object):
 
     DEFAULT_SEARCH = ['version', 'id', 'summary', 'status', 'op_sys',
                       'resolution', 'product', 'component', 'platform',
-                      'whiteboard']
+                      'whiteboard', 'depends_on']
 
     def __init__(
             self,


### PR DESCRIPTION
The depends_on property fails after retrieving a bug because it is not populated by default.

```
>>> bug = bugsy.get(1340565)
>>> bug.depends_on
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/forb1dden/.virtualenvs/jsbugmon/local/lib/python2.7/site-packages/bugsy/bug.py", line 301, in depends_on
    depends_on = [dep for dep in self._bug['depends_on']]
KeyError: 'depends_on'
```

Adding the 'depends_on' field to DEFAULT_SEARCH solves this.