### PR TITLE
Add special handling for flags object list

### DIFF
--- a/bugsy/bug.py
+++ b/bugsy/bug.py
@@ -189,7 +189,7 @@ class Bug(object):
                 if key not in self._copy or self._bug[key] != self._copy[key]:
                     changed[key] = self._bug[key]
             elif key == 'flags':
-                if sorted(self._bug.get(key, [])) != sorted(self._copy.get(key, [])):
+                if self._bug.get(key, []) != self._copy.get(key, []):
                     changed[key] = self._bug.get(key, [])
             else:
                 values_now = set(self._bug.get(key, []))

--- a/bugsy/bug.py
+++ b/bugsy/bug.py
@@ -188,6 +188,9 @@ class Bug(object):
             if key not in ARRAY_TYPES:
                 if key not in self._copy or self._bug[key] != self._copy[key]:
                     changed[key] = self._bug[key]
+            elif key == 'flags':
+                if sorted(self._bug.get(key, [])) != sorted(self._copy.get(key, [])):
+                    changed[key] = self._bug.get(key, [])
             else:
                 values_now = set(self._bug.get(key, []))
                 values_orig = set(self._copy.get(key, []))


### PR DESCRIPTION
Special handling for the flags object needs to be performed when doing a diff.  Since flags are represented an array of objects, we can't use the default set methods for performing intersection.