### PR TITLE
add precommit hook for formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+# See https://pre-commit.com for more information
+
+repos:
+-   repo: https://github.com/psf/black
+    rev: 22.12.0
+    hooks:
+    -   id: black
+        args: [--safe]
+
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+    -   id: debug-statements
+        language_version: python3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flake8
 requests
 responses
 tox
+pre-commit


### PR DESCRIPTION
## Fixes #61 

Further configuration can be made to check for linting using mypy, flake8 etc, or to run tests before every commit.

Tool used for formatting - black
